### PR TITLE
Only allow installation on SC <=3.8

### DIFF
--- a/UnitTesting.quark
+++ b/UnitTesting.quark
@@ -1,7 +1,8 @@
 (
 	\name: "UnitTesting",
 	\path: "UnitTesting", // path relative to the root Quarks folder
-	\summary: "the UnitTest class itself; required by any of the test quark packages",
+	\summary: "The UnitTesting classes. Now included in the main class library as of SC version 3.9.0.",
+	\isCompatible: { Main.versionAtMost(3, 8) },
 	\helpdoc:	"Help/UnitTest.htm",
 	\author: "initial felix, dan s, jrhb; maintained by the SuperCollider dev community"
 )


### PR DESCRIPTION
UnitTesting is only compatible with SC versions `<=3.8`. The UnitTesting quark file needs to make use of `isCompatible`. If `Main.versionAtMost(3, 8)` returns `false`, the quark will not be installed.

This change will help avoid the issue of UnitTesting installing as a dependency of other quarks and causing the class library to no longer compile.